### PR TITLE
Fix Halt-Problem in requests processing

### DIFF
--- a/src/main/java/club/thom/tem/hypixel/Hypixel.java
+++ b/src/main/java/club/thom/tem/hypixel/Hypixel.java
@@ -238,7 +238,14 @@ public class Hypixel {
                     if (request != null) {
                         logger.debug("LOOP-> Taken.");
                         requestFutures.add(request.getCompletionFuture());
-                        threadPool.submit(request::makeRequest);
+                        threadPool.submit(() -> {
+                            try {
+                                request.makeRequest();
+                            } catch (Throwable e) {
+                                logger.error(e);
+                                request.getCompletionFuture().complete(false);
+                            }
+                        });
                     } else {
                         logger.debug("LOOP-> Quit due to timeout...");
                         break;


### PR DESCRIPTION
Main loop waits till all requests are completed.
Problem occurs if a request encounters an error and doesn't give a signal back about its status.