### PR TITLE
stop leather GUI items from flagging as exotic

### DIFF
--- a/src/main/java/club/thom/tem/listeners/ToolTipListener.java
+++ b/src/main/java/club/thom/tem/listeners/ToolTipListener.java
@@ -94,7 +94,7 @@ public class ToolTipListener {
             }
         }
 
-        if (ArmourPieceData.isValidItem(itemNbt) && tem.getConfig().shouldShowArmourColourType()) {
+        if (MiscItemData.isValidItem(itemNbt) && ArmourPieceData.isValidItem(itemNbt) && tem.getConfig().shouldShowArmourColourType()) {
             // We're only caring about armour on tooltips, to add colour.
             addArmourColourType(event, itemNbt);
         }


### PR DESCRIPTION
add MiscItemData.isValidItem() check before addArmourColourType()
This filters out GUI items so autopet menu + wardrobe menu + some other various items no longer falsely flag as exotic