### PR TITLE
Stop exporting recipe GUI

### DIFF
--- a/src/main/java/club/thom/tem/export/ChestExporter.java
+++ b/src/main/java/club/thom/tem/export/ChestExporter.java
@@ -50,6 +50,9 @@ public class ChestExporter implements PacketEventListener {
     }
 
     private boolean shouldExportContainer(String containerName) {
+        if (containerName.endsWith(" Recipe")) {
+            return false;
+        }
         return exportableContainerNames.contains(containerName) ||
                 containerName.contains("Backpack") || containerName.startsWith("Pets") ||
                 containerName.startsWith("Ender Chest") || containerName.startsWith("Accessory Bag") ||


### PR DESCRIPTION
If you run `/tem export start` and then open a recipe GUI that contains one of the valid storage strings (namely 'Chest'), it will export the fake GUI items. (not anymore though :3 )