### PR TITLE
Prevent rift items from falsey flagging as exotic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 run
 .vscode
 logs
+bin

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .idea
 build
 run
+.vscode
+logs

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 repositories {
     mavenCentral()
     maven { url 'https://jitpack.io' }
-    maven { url = "https://repo.sk1er.club/repository/maven-public" }
+    maven { url = "https://repo.papermc.io/repository/maven-public" }
     maven { url = "https://repo.spongepowered.org/repository/maven-public/" }
     maven { url 'https://repo.hypixel.net/repository/Hypixel/' }
     maven { url 'https://repo.polyfrost.cc/releases' }

--- a/src/main/java/club/thom/tem/export/ItemExporter.java
+++ b/src/main/java/club/thom/tem/export/ItemExporter.java
@@ -76,8 +76,11 @@ public class ItemExporter {
                 clipboard.setContents(new StringSelection(sb.toString()), null);
             } catch (IllegalStateException ignored) {
             }
-
-            highlighter.clearExcluded();
+			
+			BlockHighlighter currentHighlighter = getHighlighter();
+            if (currentHighlighter != null) {
+                currentHighlighter.clearExcluded();
+            }
         } finally {
             lock.writeLock().unlock();
         }

--- a/src/main/java/club/thom/tem/listeners/ToolTipListener.java
+++ b/src/main/java/club/thom/tem/listeners/ToolTipListener.java
@@ -48,6 +48,7 @@ public class ToolTipListener {
 
     public ToolTipListener(TEM parent) {
         this.tem = parent;
+        this.locationListener = parent.getLocationListener();
     }
 
     private boolean shouldCopy() {

--- a/src/main/java/club/thom/tem/listeners/ToolTipListener.java
+++ b/src/main/java/club/thom/tem/listeners/ToolTipListener.java
@@ -1,6 +1,7 @@
 package club.thom.tem.listeners;
 
 import club.thom.tem.TEM;
+import club.thom.tem.listeners.LocationListener;
 import club.thom.tem.backend.requests.RequestsCache;
 import club.thom.tem.backend.requests.hex_for_id.HexAmount;
 import club.thom.tem.backend.requests.hex_for_id.HexFromItemIdRequest;
@@ -38,6 +39,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.regex.Pattern;
 
 public class ToolTipListener {
+    private final LocationListener locationListener;
     private static final Pattern nbtTagCountPattern = Pattern.compile("NBT: \\d+ tag\\(s\\)");
     TEM tem;
     ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
@@ -101,6 +103,10 @@ public class ToolTipListener {
     }
 
     private void addArmourColourType(ItemTooltipEvent event, NBTTagCompound itemNbt) {
+        String lastMode = locationListener.getLastMode();
+        if (lastMode.equalsIgnoreCase("rift")) {
+            return;
+        }
         ArmourPieceData armour = new ArmourPieceData(tem, "inventory", itemNbt);
 
         tem.getSeymour().getCloseness().runSeymourToolTip(armour, event);


### PR DESCRIPTION
Sort of a hacky solution, but I used LocRaw to ensure that we are not in the rift before continuing with addArmourColourType(). repo.sk1er.club is still down so I am not able to build this and make 100% sure it works but I was pretty careful with it