### PR TITLE
Bleached tooltip indicator fix + ghostly ghostly support

### DIFF
--- a/src/main/java/club/thom/tem/constants/CrystalColours.java
+++ b/src/main/java/club/thom/tem/constants/CrystalColours.java
@@ -8,9 +8,13 @@ public class CrystalColours {
             "B88BC9", "C6A3D4", "D9C1E3", "E5D1ED", "EFE1F5", "FCF3FF"
     );
 
+    public static final ImmutableSet<String> uncraftableCrystalColours = ImmutableSet.of(
+            "1F0030", "46085E", "54146E", "5D1C78", "63237D", "6A2C82","FCF3FF"
+    );
+
     public static boolean isCrystalColour(String hex) {
         return crystalColoursConstants.contains(hex.toUpperCase());
     }
     //WIP | from my understanding hypixel's dying system is not fully known/reversed, there's just some known possible and known impossible hexes
-    public static boolean isUncraftableCrystalColour(String hex) {return isCrystalColour(hex);}
+    public static boolean isUncraftableCrystalColour(String hex) {return uncraftableCrystalColours.contains(hex.toUpperCase());}
 }

--- a/src/main/java/club/thom/tem/constants/CrystalColours.java
+++ b/src/main/java/club/thom/tem/constants/CrystalColours.java
@@ -11,4 +11,6 @@ public class CrystalColours {
     public static boolean isCrystalColour(String hex) {
         return crystalColoursConstants.contains(hex.toUpperCase());
     }
+    //WIP | from my understanding hypixel's dying system is not fully known/reversed, there's just some known possible and known impossible hexes
+    public static boolean isUncraftableCrystalColour(String hex) {return isCrystalColour(hex);}
 }

--- a/src/main/java/club/thom/tem/constants/GhostlyColours.java
+++ b/src/main/java/club/thom/tem/constants/GhostlyColours.java
@@ -1,0 +1,29 @@
+package club.thom.tem.constants;
+
+import com.google.common.collect.ImmutableSet;
+
+public class GhostlyColours {
+    public static final ImmutableSet<String> ghostlyColorConstants = ImmutableSet.of(
+            "010101",
+            "040404",
+            "0B0B0B",
+            "171717",
+            "272727",
+            "3A3A3A",
+            "505050",
+            "686868",
+            "808080",
+            "989898",
+            "B0B0B0",
+            "C6C6C6",
+            "D9D9D9",
+            "E9E9E9",
+            "F5F5F5",
+            "FCFCFC",
+            "FFFFFF"
+    );
+
+    public static boolean isGhostlyColor(String hex) {
+        return ghostlyColorConstants.contains(hex.toUpperCase());
+    }
+}

--- a/src/main/java/club/thom/tem/constants/VariantColours.java
+++ b/src/main/java/club/thom/tem/constants/VariantColours.java
@@ -59,6 +59,8 @@ public class VariantColours {
             return GhostlyColours.isGhostlyColor(hexCode);
         }
         if (itemId.startsWith("LEATHER") && !itemId.contains(":")) {
+            if (FairyColours.isFairyColour(hexCode)) return false;
+            if (CrystalColours.isUncraftableCrystalColour(hexCode)) return false;
             return true;
         }
         if (itemId.equals("LEGGINGS_OF_THE_COVEN")) {

--- a/src/main/java/club/thom/tem/constants/VariantColours.java
+++ b/src/main/java/club/thom/tem/constants/VariantColours.java
@@ -55,10 +55,10 @@ public class VariantColours {
         if (itemId.startsWith("GREAT_SPOOK")) {
             return SpookColours.isSpookColour(hexCode);
         }
-        if (itemId.startsWith("LEATHER") && !itemId.contains(":")) {
-            return true;
-        }
         if (itemId.equals("GHOST_BOOTS")) {
+            return GhostlyColours.isGhostlyColor(hexCode);
+        }
+        if (itemId.startsWith("LEATHER") && !itemId.contains(":")) {
             return true;
         }
         if (itemId.equals("LEGGINGS_OF_THE_COVEN")) {

--- a/src/main/java/club/thom/tem/listeners/ToolTipListener.java
+++ b/src/main/java/club/thom/tem/listeners/ToolTipListener.java
@@ -112,7 +112,7 @@ public class ToolTipListener {
 
         tem.getSeymour().getCloseness().runSeymourToolTip(armour, event);
 
-        HexUtil.Modifier armourTypeModifier = new HexUtil(tem.getItems()).getModifier(armour.getItemId(), armour.getHexCode(), armour.getCreationTimestamp(), armour.hasTrueColor());
+        HexUtil.Modifier armourTypeModifier = new HexUtil(tem.getItems()).getModifier(armour.getItemId(), armour.getHexCode(true), armour.getCreationTimestamp(), armour.hasTrueColor());
         String colourCode = armourTypeModifier.getColourCode();
         int ownerCount = checkArmourOwners(armour);
         String toolTipString = (colourCode + armourTypeModifier).replace("_", " ");

--- a/src/main/java/club/thom/tem/models/inventory/item/ArmourPieceData.java
+++ b/src/main/java/club/thom/tem/models/inventory/item/ArmourPieceData.java
@@ -108,9 +108,9 @@ public class ArmourPieceData extends InventoryItemData {
         return String.format("%06X", colourInt);
     }
 
-    public String getHexCode() {
+    public String getHexCode(boolean includeBleached) {
         NBTTagCompound extraAttributes = getExtraAttributes();
-        if (!extraAttributes.hasKey("color") || extraAttributes.getString("color").equals("160:101:64")) {
+        if (!extraAttributes.hasKey("color") || (!includeBleached && extraAttributes.getString("color").equals("160:101:64"))) {
             return getHexFromDisplayColour();
         }
         String[] colourArrayAsString = extraAttributes.getString("color").split(":");
@@ -119,6 +119,10 @@ public class ArmourPieceData extends InventoryItemData {
             colourArray[i] = Integer.parseInt(colourArrayAsString[i]);
         }
         return convertIntArrayToHex(colourArray).toUpperCase();
+    }
+
+    public String getHexCode() {
+        return getHexCode(false);
     }
 
     public boolean hasTrueColor() {

--- a/src/main/java/club/thom/tem/util/HexUtil.java
+++ b/src/main/java/club/thom/tem/util/HexUtil.java
@@ -65,6 +65,10 @@ public class HexUtil {
             return Modifier.SPOOK_SPOOK;
         }
 
+        if (itemId.equals("GHOST_BOOTS") && GhostlyColours.isGhostlyColor(hexCode) && isTrueHex) {
+            return Modifier.GHOSTLY_GHOSTLY;
+        }
+
         if (VariantColours.isVariantColour(itemId, hexCode)) {
             return Modifier.ORIGINAL;
         }
@@ -85,6 +89,7 @@ public class HexUtil {
         FAIRY_FAIRY,
         CRYSTAL_CRYSTAL,
         SPOOK_SPOOK,
+        GHOSTLY_GHOSTLY
         ;
 
         public String getColourCode() {
@@ -102,6 +107,7 @@ public class HexUtil {
                 case ORIGINAL:
                     return EnumChatFormatting.DARK_GRAY.toString();
                 case UNDYED:
+                case GHOSTLY_GHOSTLY:
                     return EnumChatFormatting.GRAY.toString();
                 case SPOOK:
                 case SPOOK_SPOOK:

--- a/src/main/java/club/thom/tem/util/HexUtil.java
+++ b/src/main/java/club/thom/tem/util/HexUtil.java
@@ -35,13 +35,19 @@ public class HexUtil {
             if (VariantColours.isVariantColour(itemId, hexCode)) {
                 if (isTrueHex) return Modifier.FAIRY_FAIRY;
                 else return Modifier.ORIGINAL;
-            } else return Modifier.OG_FAIRY;
+            } else {
+                if (isTrueHex) return Modifier.OG_FAIRY;
+                else return Modifier.GHOST_FAIRY;
+            }
         }
         if (FairyColours.isFairyColour(hexCode)) {
             if (VariantColours.isVariantColour(itemId, hexCode)) {
                 if (isTrueHex) return Modifier.FAIRY_FAIRY;
                 else return Modifier.ORIGINAL;
-            } else return Modifier.FAIRY;
+            } else {
+                if (isTrueHex) return Modifier.FAIRY;
+                else return Modifier.GHOST_FAIRY;
+            }
         }
         if (hexCode.equals("A06540") || hexCode.equals("UNDYED")) {
             return Modifier.UNDYED;
@@ -58,7 +64,9 @@ public class HexUtil {
         }
 
         if (itemId.startsWith("FAIRY_") && SpookColours.isSpookColour(hexCode)) {
-            return Modifier.SPOOK;
+            if (isTrueHex){
+                return Modifier.SPOOK;
+            } else return Modifier.GHOST_SPOOK;
         }
 
         if (itemId.startsWith("GREAT_SPOOK_") && SpookColours.isSpookColour(hexCode) && isTrueHex) {
@@ -89,7 +97,9 @@ public class HexUtil {
         FAIRY_FAIRY,
         CRYSTAL_CRYSTAL,
         SPOOK_SPOOK,
-        GHOSTLY_GHOSTLY
+        GHOSTLY_GHOSTLY,
+        GHOST_FAIRY,
+        GHOST_SPOOK
         ;
 
         public String getColourCode() {
@@ -99,6 +109,7 @@ public class HexUtil {
                     return EnumChatFormatting.AQUA.toString();
                 case FAIRY:
                 case FAIRY_FAIRY:
+                case GHOST_FAIRY:
                     return EnumChatFormatting.LIGHT_PURPLE.toString();
                 case OG_FAIRY:
                     return EnumChatFormatting.DARK_PURPLE.toString();
@@ -111,6 +122,7 @@ public class HexUtil {
                     return EnumChatFormatting.GRAY.toString();
                 case SPOOK:
                 case SPOOK_SPOOK:
+                case GHOST_SPOOK:
                     return EnumChatFormatting.RED.toString();
                 case GLITCHED:
                     // magic grey pipe in front of glitched armour


### PR DESCRIPTION
True bleached/undyed pieces (bleached before patch with `"color": "160:101:64"`) used to try to fallback to display color to determine hex. This meant that pieces of bleached fairy (or other armors that switch colors) would stop showing tooltip as "UNDYED" if they were worn (wearing them doesn't remove the `color:` tag, they become visibly bleached once strong updated).
Ghostly also has some hexes like fairy where they would save before a certain update inside `color:` and stay like that permanently.